### PR TITLE
chore: upgrade GitHub Actions to Node.js 24 compatible versions

### DIFF
--- a/.github/workflows/template-create-release-from-pr.yml
+++ b/.github/workflows/template-create-release-from-pr.yml
@@ -68,7 +68,7 @@ jobs:
       is_prerelease: ${{ steps.metadata.outputs.is_prerelease }}
       releasable: ${{ steps.metadata.outputs.releasable }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - id: metadata
@@ -119,7 +119,7 @@ jobs:
       - name: Create app token
         id: app-token
         if: inputs.use-github-app-token == true
-        uses: actions/create-github-app-token@v2
+        uses: actions/create-github-app-token@v3
         with:
           app-id: ${{ inputs.github-app-id }}
           private-key: ${{ secrets.github-app-private-key }}
@@ -139,7 +139,7 @@ jobs:
           fi
 
           echo "token=$token" >>"$GITHUB_OUTPUT"
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
           persist-credentials: false

--- a/.github/workflows/template-prepare-release-pr.yml
+++ b/.github/workflows/template-prepare-release-pr.yml
@@ -76,11 +76,11 @@ jobs:
         latest_version: ${{ steps.ver.outputs.latest_version }}
         commits_since_latest_version: ${{ steps.ver.outputs.commits_since_latest_version }}
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
             ref: ${{ inputs.branch }}
-        - uses: actions/setup-go@v5
+        - uses: actions/setup-go@v6
           with:
               go-version: '^1.24'
               cache: false
@@ -146,7 +146,7 @@ jobs:
       env:
         PRERELEASE_REGEX: ^v[0-9]+\.[0-9]+\.[0-9]+-[0-9A-Za-z-]+(\.[0-9A-Za-z-]+)*
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
             ref: ${{ inputs.branch }}
@@ -200,7 +200,7 @@ jobs:
             done
         - name: Create stable release PR
           id: pull-request
-          uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+          uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
           with:
             base: ${{ inputs.branch }}
             delete-branch: true
@@ -227,7 +227,7 @@ jobs:
         contents: write
         issues: write # required to create labels
       steps:
-        - uses: actions/checkout@v4
+        - uses: actions/checkout@v6
           with:
             fetch-depth: 0
             ref: ${{ inputs.branch }}
@@ -269,7 +269,7 @@ jobs:
             done
         - name: Create prerelease PR
           id: pull-request
-          uses: peter-evans/create-pull-request@271a8d0340265f705b14b6d32b9829c1cb33d45e # v7.0.8
+          uses: peter-evans/create-pull-request@c0f553fe549906ede9cf27b5156039d195d2ece0 # v8.1.0
           with:
             base: ${{ inputs.branch }}
             delete-branch: true

--- a/.github/workflows/template-unreleased-pr-metadata.yml
+++ b/.github/workflows/template-unreleased-pr-metadata.yml
@@ -18,7 +18,7 @@ jobs:
       unreleased_pull_requests: ${{ steps.metadata.outputs.unreleased_pull_requests }}
       unreleased_pull_request_count: ${{ steps.metadata.outputs.unreleased_pull_request_count }}
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
         with:
           fetch-depth: 0
       - name: Metadata


### PR DESCRIPTION
Upgrade actions to prevent deprecation warnings and ensure compatibility before the June 2, 2026 Node.js 24 enforcement deadline.

- actions/checkout: v4 → v6
- actions/setup-go: v5 → v6
- actions/create-github-app-token: v2 → v3
- peter-evans/create-pull-request: v7.0.8 → v8.1.0